### PR TITLE
created apps.py in root folder to override the default admin site

### DIFF
--- a/Chapter04/final/bookr/apps.py
+++ b/Chapter04/final/bookr/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class ReviewsAdminConfig(AdminConfig):
+    default_site = 'admin.BookrAdminSite'

--- a/Chapter04/final/bookr/bookr/settings.py
+++ b/Chapter04/final/bookr/bookr/settings.py
@@ -31,7 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'reviews.apps.ReviewsAdminConfig',
+    'apps.ReviewsAdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/Chapter04/final/bookr/reviews/apps.py
+++ b/Chapter04/final/bookr/reviews/apps.py
@@ -3,4 +3,3 @@ from django.apps import AppConfig
 
 class ReviewsConfig(AppConfig):
     name = 'reviews'
-    default=False

--- a/Chapter04/final/bookr/reviews/apps.py
+++ b/Chapter04/final/bookr/reviews/apps.py
@@ -1,9 +1,6 @@
 from django.apps import AppConfig
-from django.contrib.admin.apps import AdminConfig
+
 
 class ReviewsConfig(AppConfig):
     name = 'reviews'
-
-class ReviewsAdminConfig(AdminConfig):
-    default_site = 'admin.BookrAdminSite'
-
+    default=False


### PR DESCRIPTION
Sir,
the earlier code was not working in Django 3.2 and was raising following error...
`RuntimeError: 'reviews.apps' declares more than one default AppConfig: 'AdminConfig', 'ReviewsAdminConfig'`
after removing parts of code under reviews/apps.py to rool folder under apps.py  its working fine.