### PR TITLE
Update admin.py get_urls() method

### DIFF
--- a/Chapter10/Exercise10.04/bookr_admin/admin.py
+++ b/Chapter10/Exercise10.04/bookr_admin/admin.py
@@ -15,4 +15,4 @@ class BookrAdmin(admin.AdminSite):
         url_patterns = [
             path("admin_profile", self.admin_view(self.profile_view))
         ]
-        return urls + url_patterns
+        return url_patterns + urls


### PR DESCRIPTION
In Django version 4.0.6 need to change the order of adding urls otherwise I get error 404 in http://localhost:8000/admin/admin_profile
Problem discussion:
https://stackoverflow.com/questions/68368142/catch-all-view-break-url-patterns-in-django